### PR TITLE
Adding image titles for desktop view

### DIFF
--- a/app/components/HomeImage.tsx
+++ b/app/components/HomeImage.tsx
@@ -1,22 +1,19 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import Image from "next/image"
 import profilePhotoData from "../../profilePhotoData.json"
 
-export default function HomeImage() {
-  // using ` | any` here to avoid error on `.path/alt/id` for the {} prior to loading anything into state
-  const [profilePic, setProfilePic] = useState<ProfilePic | any>({}) 
+export default async function HomeImage() {
   const photos: ProfilePic[] = profilePhotoData.photos 
 
   function getRandomInt(max: number) {
     return Math.floor(Math.random() * max);
   }
 
-  useEffect(() => {
+  function getPhoto() {
     const num = getRandomInt(photos.length)
-    setProfilePic(photos[num])
-  }, [])
+    return photos[num]
+  }
+
+  const profilePic = getPhoto()
 
   return (
     <figure className="about-fig">

--- a/app/components/HomeImage.tsx
+++ b/app/components/HomeImage.tsx
@@ -1,19 +1,22 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Image from "next/image"
 import profilePhotoData from "../../profilePhotoData.json"
 
-export default async function HomeImage() {
+export default function HomeImage() {
+  // using ` | any` here to avoid error on `.path/alt/id` for the {} prior to loading anything into state
+  const [profilePic, setProfilePic] = useState<ProfilePic | any>({}) 
   const photos: ProfilePic[] = profilePhotoData.photos 
 
   function getRandomInt(max: number) {
     return Math.floor(Math.random() * max);
   }
 
-  function getPhoto() {
+  useEffect(() => {
     const num = getRandomInt(photos.length)
-    return photos[num]
-  }
-
-  const profilePic = getPhoto()
+    setProfilePic(photos[num])
+  }, [])
 
   return (
     <figure className="about-fig">

--- a/app/components/ImageGrid.tsx
+++ b/app/components/ImageGrid.tsx
@@ -3,7 +3,9 @@
 type Props = {
   imageList: any[],
   openImageViewer: (index: number) => void,
-  keyboardNav: (e: React.KeyboardEvent<HTMLImageElement>, index: number) => void
+  // keyboardNav: (e: React.KeyboardEvent<HTMLImageElement>, index: number) => void //? For if the keydown is on the img element
+  keyboardNav: (e: React.KeyboardEvent<HTMLDivElement>, index: number) => void //* For if the keydown is on the div element
+
 }
 
 export default function ImageGrid( {imageList, openImageViewer, keyboardNav}: Props ) {
@@ -12,15 +14,17 @@ export default function ImageGrid( {imageList, openImageViewer, keyboardNav}: Pr
       <p className="instruction">Select an image to view it in full screen</p>
       <div className="image-grid">
         {imageList.map((image, index) => (
-          <div className="img-card" key={image.asset_id}>
+          <div 
+            className="img-card" key={image.asset_id}
+            onClick={ () => openImageViewer(index) }
+            onKeyDown={ (event) => keyboardNav(event,index)}
+            tabIndex={0}
+          >
             <img 
               className='thumbnail'
               src={image.secure_url} 
               alt={image.context?.custom?.alt || image.context?.alt || ""} 
-              onClick={ () => openImageViewer(index) }
-              onKeyDown={ (event) => keyboardNav(event,index)}
               // key={image.asset_id}
-              tabIndex={0}
               width={356}
               height={238}
             />

--- a/app/components/ImageGrid.tsx
+++ b/app/components/ImageGrid.tsx
@@ -5,7 +5,6 @@ type Props = {
   openImageViewer: (index: number) => void,
   // keyboardNav: (e: React.KeyboardEvent<HTMLImageElement>, index: number) => void //? For if the keydown is on the img element
   keyboardNav: (e: React.KeyboardEvent<HTMLDivElement>, index: number) => void //* For if the keydown is on the div element
-
 }
 
 export default function ImageGrid( {imageList, openImageViewer, keyboardNav}: Props ) {

--- a/app/components/ImageGrid.tsx
+++ b/app/components/ImageGrid.tsx
@@ -12,17 +12,21 @@ export default function ImageGrid( {imageList, openImageViewer, keyboardNav}: Pr
       <p className="instruction">Select an image to view it in full screen</p>
       <div className="image-grid">
         {imageList.map((image, index) => (
-          <img 
-            className='thumbnail'
-            src={image.secure_url} 
-            alt={image.context?.custom?.alt || image.context?.alt || ""} 
-            onClick={ () => openImageViewer(index) }
-            onKeyDown={ (event) => keyboardNav(event,index)}
-            key={image.asset_id}
-            tabIndex={0}
-            width={356}
-            height={238}
-          />
+          <div className="img-card" key={image.asset_id}>
+            <img 
+              className='thumbnail'
+              src={image.secure_url} 
+              alt={image.context?.custom?.alt || image.context?.alt || ""} 
+              onClick={ () => openImageViewer(index) }
+              onKeyDown={ (event) => keyboardNav(event,index)}
+              // key={image.asset_id}
+              tabIndex={0}
+              width={356}
+              height={238}
+            />
+            {/* Cloudinary calls shows "title" in their UI, but serves it as "caption" in the custom metadata */}
+            <footer className="img-footer">{image.context?.custom?.caption || image.context?.caption}</footer>
+          </div>
         ))}
       </div>
     </div>

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -127,7 +127,7 @@ export default function Gallery() {
   };
 
   // event type inferred from context
-  const keyboardNav = (e: React.KeyboardEvent<HTMLImageElement>, index: number) => {
+  const keyboardNav = (e: React.KeyboardEvent<HTMLDivElement>, index: number) => {
     if (e.defaultPrevented) {
       return;
     }

--- a/app/globals.css
+++ b/app/globals.css
@@ -330,6 +330,11 @@ label:focus-within,
   grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
 }
 
+.img-card {
+  display: flex;
+  flex-direction: column;
+}
+
 .load-more {
   margin-top: 2rem;
   border: 0.125rem solid black;
@@ -391,6 +396,14 @@ footer {
   justify-content: center;
 }
 
+.img-footer {
+  height: fit-content;
+  border: none;
+  border-bottom: 0.2rem solid aliceblue;
+  border-radius: 0.5rem;
+  padding: 0.25rem 0.25rem 0.5rem 0.25rem; /* T R B L */
+} 
+
 .footer-section {
   display: flex;
   justify-content: center;
@@ -423,6 +436,11 @@ footer {
 @media (max-width: 95rem) {
   .App, .image-grid, .tags-form {
     width: auto;
+  }
+
+  .image-grid {
+    margin-right: 1rem;
+    margin-left: 1rem;
   }
 }
 
@@ -458,10 +476,10 @@ footer {
     font-size: 1rem;
   }
 
-  .image-grid {
+  /* .image-grid {
     margin-right: 1rem;
     margin-left: 1rem;
-  }
+  } */
 
   .mobile-image-grid {
     display: flex;

--- a/app/globals.css
+++ b/app/globals.css
@@ -270,7 +270,7 @@ input[type="checkbox"] {
 
 .checked {
   filter: invert(1);
-  font-weight: bold;
+  /* font-weight: bold; */
 }
 
 label:hover, 
@@ -308,6 +308,7 @@ label:focus-within,
   box-sizing: border-box;
 }
 
+/* MOVING HOVER EFFECT TO IMG-CARD
 .thumbnail:hover {
   z-index: 1;
   background-color: black;
@@ -316,7 +317,7 @@ label:focus-within,
     rgba(250, 250, 250, 0.6) -0.25rem -0.25rem 0.6rem 0.05rem,
     rgba(250, 250, 250, 0.6) 0.25rem -0.25rem 0.6rem 0.05rem, 
     rgb(250, 250, 250, 0.6) -0.25rem .25rem 0.6rem 0.05rem;
-}
+} */
 
 .grid-wrapper {
   display: flex;
@@ -333,6 +334,14 @@ label:focus-within,
 .img-card {
   display: flex;
   flex-direction: column;
+}
+
+.img-card:hover > .thumbnail {
+  border-color: #c1ccc5;
+}
+
+.img-card:hover > .img-footer {
+  filter: invert(1);
 }
 
 .load-more {
@@ -402,6 +411,7 @@ footer {
   border-bottom: 0.2rem solid aliceblue;
   border-radius: 0.5rem;
   padding: 0.25rem 0.25rem 0.5rem 0.25rem; /* T R B L */
+  margin-top: 0.5rem;
 } 
 
 .footer-section {

--- a/app/globals.css
+++ b/app/globals.css
@@ -336,11 +336,13 @@ label:focus-within,
   flex-direction: column;
 }
 
-.img-card:hover > .thumbnail {
+.img-card:hover > .thumbnail,
+.img-card:focus-visible > .thumbnail {
   border-color: #c1ccc5;
 }
 
-.img-card:hover > .img-footer {
+.img-card:hover > .img-footer,
+.img-card:focus-visible > .img-footer  {
   filter: invert(1);
 }
 


### PR DESCRIPTION
To add a bit more useful content to the desktop version of the gallery, I have updated the metadata in Cloudinary to include a title for each image. It is either the name of the plant or animal (or vague descriptor if n/a), or the name of the location for the landscape images. 

I've also tweaked some CSS to make that addition look nice, and updated the hover/focus effects to accommodate the new text areas.